### PR TITLE
ssh-remote 1.2.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,8 @@ Contributions are more than welcome!
 
 Thanks! :sweat_smile:
 
+
+
 [1]: https://github.com/IonicaBizau/ssh-remote/issues
 
 [2]: https://github.com/IonicaBizau/code-style

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,4 +1,5 @@
 ## Documentation
+
 You can see below the API reference of this module.
 
 ### `SshRemote(path, callback)`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
+
 # `$ ssh-remote` [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/ssh-remote.svg)](https://www.npmjs.com/package/ssh-remote) [![Downloads](https://img.shields.io/npm/dt/ssh-remote.svg)](https://www.npmjs.com/package/ssh-remote) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Automagically switch on the SSH remote url in a Git repository.
+
 
 Sometimes it happens to have repositories closed with http(s) protocol. I have 2FA enabled on GitHub and my password is complicated anyway. Since I have SSH configured on my machines, I want to use it, I never knew the SSH url format.
 
@@ -12,25 +14,29 @@ $ ssh-remote
 
 ...and let the magic happen.
 
+
 [![ssh-remote](http://i.imgur.com/Unb4VUA.png)](#)
 
-## Installation
+## :cloud: Installation
 
 You can install the package globally and use it as command line tool:
+
 
 ```sh
 $ npm i -g ssh-remote
 ```
 
+
 Then, run `ssh-remote --help` and see what the CLI tool can do.
 
-```sh
+
+```
 $ ssh-remote --help
 Usage: ssh-remote [options]
 
 Options:
-  -p, --path <path>  Set another path.            
-  -h, --help         Displays this help.          
+  -p, --path <path>  Set another path.
+  -h, --help         Displays this help.
   -v, --version      Displays version information.
 
 Examples:
@@ -40,13 +46,16 @@ Examples:
 Documentation can be found at https://github.com/IonicaBizau/ssh-remote
 ```
 
-## Example
+## :clipboard: Example
+
 
 Here is an example how to use this package as library. To install it locally, as library, you can do that using `npm`:
 
 ```sh
 $ npm i --save ssh-remote
 ```
+
+
 
 ```js
 var SshRemote = require("ssh-remote");
@@ -58,17 +67,15 @@ SshRemote();
 SshRemote("path/to/some/dir");
 ```
 
-## Documentation
+## :memo: Documentation
 
 For full API reference, see the [DOCUMENTATION.md][docs] file.
 
-## How to contribute
+## :yum: How to contribute
 Have an idea? Found a bug? See [how to contribute][contributing].
 
-## Where is this library used?
-If you are using this library in one of your projects, add it in this list. :sparkles:
 
-## License
+## :scroll: License
 
 [MIT][license] © [Ionică Bizău][website]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssh-remote",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Automagically switch on the SSH remote url in a Git repository.",
   "main": "lib/index.js",
   "bin": {
@@ -56,5 +56,16 @@
         ]
       }
     ]
-  }
+  },
+  "files": [
+    "bin/",
+    "app/",
+    "lib/",
+    "dist/",
+    "src/",
+    "resources/",
+    "menu/",
+    "cli.js",
+    "index.js"
+  ]
 }


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
